### PR TITLE
fix: docking window title bar

### DIFF
--- a/DockingPaneContainer.cpp
+++ b/DockingPaneContainer.cpp
@@ -91,6 +91,7 @@ DockingPaneContainer::DockingPaneContainer(QString title, QString id, QWidget *p
 
     m_headerWidget->setLayout(hLayout);
     m_headerWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    m_headerWidget->setMaximumHeight(20);
 
     vLayout->addWidget(m_headerWidget);
 


### PR DESCRIPTION
the docking window title bar expands incorrectly unless the correct sizing policy is applied to the child widget, this patch removes that requirement.