### PR TITLE
[Tech Debt] Tidy DockAutoHideButton class

### DIFF
--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -57,7 +57,7 @@ void DockAutoHideButton::init()
 
     m_hovered = false;
 
-    m_hoverTimer = new QTimer();
+    m_hoverTimer = new QTimer(this);
 
     m_hoverTimer->setInterval(1000);
 

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -26,11 +26,9 @@
 #include "DockAutoHideButton.h"
 
 DockAutoHideButton::DockAutoHideButton(DockAutoHideButton::Position pos, QWidget* parent)
-: QPushButton(parent)
+: QPushButton(parent), m_pos(pos)
 {
     init();
-
-    m_pos = pos;
 }
 
 DockAutoHideButton::DockAutoHideButton(const QString& text, QWidget* parent)

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -17,11 +17,13 @@
  * along with DockingPanes.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "DockAutoHideButton.h"
-#include <QStylePainter>
-#include <QFont>
 #include <QDebug>
+#include <QFont>
+#include <QStylePainter>
+
 #include <QTimer>
+
+#include "DockAutoHideButton.h"
 
 DockAutoHideButton::DockAutoHideButton(DockAutoHideButton::Position pos, QWidget* parent)
 : QPushButton(parent)

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -21,7 +21,6 @@
 #include <QFont>
 #include <QStyleOptionButton>
 #include <QStylePainter>
-
 #include <QTimer>
 
 #include "DockAutoHideButton.h"
@@ -68,7 +67,7 @@ void DockAutoHideButton::init()
 
     m_hoverTimer->setInterval(1000);
 
-    connect(m_hoverTimer,SIGNAL(timeout()), this, SLOT(onTimerElapsed()));
+    connect(m_hoverTimer,&QTimer::timeout, this, &DockAutoHideButton::onTimerElapsed);
 }
 
 Qt::Orientation DockAutoHideButton::orientation() const
@@ -152,7 +151,7 @@ void DockAutoHideButton::onTimerElapsed(void)
 
         timer->stop();
 
-        emit openFlyout();
+        Q_EMIT openFlyout();
     }
 }
 

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -47,8 +47,8 @@ DockAutoHideButton::DockAutoHideButton(const QIcon& icon, const QString& text, Q
 
 void DockAutoHideButton::init()
 {
-    orientation_ = Qt::Horizontal;
-    mirrored_ = false;
+    m_orientation = Qt::Horizontal;
+    m_mirrored = false;
     m_swapDirection = false;
 
     this->setFont(QFont("Segoe UI", 9));
@@ -68,7 +68,7 @@ void DockAutoHideButton::init()
 
 Qt::Orientation DockAutoHideButton::orientation() const
 {
-    return orientation_;
+    return m_orientation;
 }
 
 void DockAutoHideButton::swapDirection(bool state)
@@ -78,7 +78,7 @@ void DockAutoHideButton::swapDirection(bool state)
 
 void DockAutoHideButton::setOrientation(Qt::Orientation orientation)
 {
-    orientation_ = orientation;
+    m_orientation = orientation;
 
     switch (orientation) {
         case Qt::Horizontal: {
@@ -95,12 +95,12 @@ void DockAutoHideButton::setOrientation(Qt::Orientation orientation)
 
 bool DockAutoHideButton::mirrored() const
 {
-    return mirrored_;
+    return m_mirrored;
 }
 
 void DockAutoHideButton::setMirrored(bool mirrored)
 {
-    mirrored_ = mirrored;
+    m_mirrored = mirrored;
 }
 
 QSize DockAutoHideButton::sizeHint() const
@@ -111,7 +111,7 @@ QSize DockAutoHideButton::sizeHint() const
     size.setWidth(fm.width(this->text()));
     size.setHeight(60);
 
-    if (orientation_ == Qt::Vertical) {
+    if (m_orientation == Qt::Vertical) {
         size.transpose();
     }
 
@@ -168,9 +168,9 @@ void DockAutoHideButton::paintEvent(QPaintEvent*)
 
     p.setPen(textColor);
 
-    switch (orientation_) {
+    switch (m_orientation) {
         case Qt::Horizontal: {
-            if (mirrored_) {
+            if (m_mirrored) {
                 p.rotate(180);
                 p.translate(-width(), -height());
             }
@@ -189,7 +189,7 @@ void DockAutoHideButton::paintEvent(QPaintEvent*)
         }
 
         case Qt::Vertical: {
-            if (mirrored_) {
+            if (m_mirrored) {
                 p.rotate(-90);
                 p.translate(-height(), 0);
             } else {
@@ -216,7 +216,7 @@ QStyleOptionButton* DockAutoHideButton::getStyleOption() const
 
     opt->initFrom(this);
 
-    if (orientation_ == Qt::Vertical) {
+    if (m_orientation == Qt::Vertical) {
         QSize size = opt->rect.size();
 
         size.transpose();

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -45,10 +45,6 @@ DockAutoHideButton::DockAutoHideButton(const QIcon& icon, const QString& text, Q
     init();
 }
 
-DockAutoHideButton::~DockAutoHideButton()
-{
-}
-
 void DockAutoHideButton::init()
 {
     orientation_ = Qt::Horizontal;

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -156,9 +156,8 @@ void DockAutoHideButton::onTimerElapsed(void)
     }
 }
 
-void DockAutoHideButton::paintEvent(QPaintEvent* event)
+void DockAutoHideButton::paintEvent(QPaintEvent*)
 {
-    Q_UNUSED(event);
     QStylePainter p(this);
     QColor color, textColor;
 

--- a/src/DockAutoHideButton.cpp
+++ b/src/DockAutoHideButton.cpp
@@ -19,6 +19,7 @@
 
 #include <QDebug>
 #include <QFont>
+#include <QStyleOptionButton>
 #include <QStylePainter>
 
 #include <QTimer>
@@ -215,25 +216,25 @@ void DockAutoHideButton::paintEvent(QPaintEvent* event)
     }
 }
 
-QStyleOptionButton DockAutoHideButton::getStyleOption() const
+QStyleOptionButton* DockAutoHideButton::getStyleOption() const
 {
-    QStyleOptionButton opt;
+    QStyleOptionButton* opt = new QStyleOptionButton();
 
-    opt.initFrom(this);
+    opt->initFrom(this);
 
     if (orientation_ == Qt::Vertical) {
-        QSize size = opt.rect.size();
+        QSize size = opt->rect.size();
 
         size.transpose();
 
-        opt.rect.setSize(size);
+        opt->rect.setSize(size);
     }
 
-    opt.features = QStyleOptionButton::None;
-    opt.features |= QStyleOptionButton::Flat;
-    opt.text = text();
-    opt.icon = icon();
-    opt.iconSize = iconSize();
+    opt->features = QStyleOptionButton::None;
+    opt->features |= QStyleOptionButton::Flat;
+    opt->text = text();
+    opt->icon = icon();
+    opt->iconSize = iconSize();
 
     return opt;
 }

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -21,11 +21,11 @@
 #define DOCKAUTOHIDEBUTTON_H
 
 #include <QPushButton>
-#include <QStyleOptionButton>
 
 #include "DockingPaneBase.h"
 #include "DockingPaneContainer.h"
 
+class QStyleOptionButton;
 class QTimer;
 
 class DockAutoHideButton : public QPushButton
@@ -75,7 +75,7 @@ class DockAutoHideButton : public QPushButton
         void onTimerElapsed(void);
 
     private:
-        QStyleOptionButton getStyleOption() const;
+        QStyleOptionButton* getStyleOption() const;
         void init();
 
         Qt::Orientation orientation_;

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -22,9 +22,11 @@
 
 #include <QPushButton>
 #include <QStyleOptionButton>
+
 #include "DockingPaneBase.h"
 #include "DockingPaneContainer.h"
-#include <QTimer>
+
+class QTimer;
 
 class DockAutoHideButton : public QPushButton
 {

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -74,8 +74,8 @@ class DockAutoHideButton : public QPushButton
         void init();
         void onTimerElapsed(void);
 
-        Qt::Orientation orientation_;
-        bool mirrored_;
+        Qt::Orientation m_orientation;
+        bool m_mirrored;
         bool m_hovered;
         DockingPaneBase *m_dockingPane;
         DockingPaneContainer *m_paneContainer;

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -45,7 +45,6 @@ class DockAutoHideButton : public QPushButton
         DockAutoHideButton(Position pos, QWidget* parent = 0);
         DockAutoHideButton(const QString& text, QWidget* parent = 0);
         DockAutoHideButton(const QIcon& icon, const QString& text, QWidget* parent = 0);
-        ~DockAutoHideButton();
 
         Qt::Orientation orientation() const;
         void setOrientation(Qt::Orientation orientation);

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -55,7 +55,7 @@ class DockAutoHideButton : public QPushButton
 
         void swapDirection(bool state);
 
-        QSize sizeHint() const;
+        virtual QSize sizeHint() const override;
         Position position(void);
         void setPane(DockingPaneContainer *container, DockingPaneBase *pane);
 

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -64,9 +64,9 @@ class DockAutoHideButton : public QPushButton
         DockingPaneContainer *container(void);
 
     protected:
-        void paintEvent(QPaintEvent* event);
-        void enterEvent(QEvent *event);
-        void leaveEvent(QEvent *event);
+        virtual void paintEvent(QPaintEvent* event) override;
+        virtual void enterEvent(QEvent *event) override;
+        virtual void leaveEvent(QEvent *event) override;
 
     signals:
         void openFlyout(void);

--- a/src/DockAutoHideButton.h
+++ b/src/DockAutoHideButton.h
@@ -42,7 +42,6 @@ class DockAutoHideButton : public QPushButton
             Bottom
         };
 
-    public:
         DockAutoHideButton(Position pos, QWidget* parent = 0);
         DockAutoHideButton(const QString& text, QWidget* parent = 0);
         DockAutoHideButton(const QIcon& icon, const QString& text, QWidget* parent = 0);
@@ -68,15 +67,13 @@ class DockAutoHideButton : public QPushButton
         virtual void enterEvent(QEvent *event) override;
         virtual void leaveEvent(QEvent *event) override;
 
-    signals:
+    Q_SIGNALS:
         void openFlyout(void);
-
-    private slots:
-        void onTimerElapsed(void);
 
     private:
         QStyleOptionButton* getStyleOption() const;
         void init();
+        void onTimerElapsed(void);
 
         Qt::Orientation orientation_;
         bool mirrored_;


### PR DESCRIPTION
**Changes:**
* Try to forward declare as many classes as possible, to speed up builds (even though this is a relatively small library, I think it's a good practice).
* Sort `#includes` in alphabetic order and split them between Qt-related ones and local headers. This will help on reducing merge conflicts and makes duplicates evident. Please let me know WDYT about this policy.
* Use Qt5 syntax for connecting signals/slots. [Here an article on why using it](https://woboq.com/blog/new-signals-slots-syntax-in-qt5.html). This allows to remove the `slots:` keyword on the headers. On another hand, I used `Q_EMIT` and `Q_SIGNALS` instead of `emit` and `signals` respectively. This is useful when you're combining Qt code with other C++ code that also contains the identifier `emit`.
* Add `virtual` and `override` keyword to inherited methods. Even though `override` does imply that the method is virtual, I added `virtual` for more clarity. I can remove this redundancy if needed.
* ...And some minor changes (one change per commit).

**Possible things to do:**
* Remove method `getStyleOption()`? It seems to be unused.
* Remove `#include <QDebug>` since it is not used. If someone wants to debug something, then include while developing and then remove it.
* Remove `this->` references? They are redundant. Or maybe leave them for clarity?
* Unify along the whole library if default arguments for `parent` will be `0`, `NULL` or `nullptr` (the three of them are across the files). IMO I rather `nullptr`.
* Qt 5.15 recommends to use `QFontMetrics::horizontalAdvance()` instead of `QFontMetrics::width() (deprecated)`.

Any suggestion/comment please let me know. Thank you!