### PR TITLE
[Tech Debt] Tidy DockingFrameStickers class

### DIFF
--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -39,37 +39,25 @@ DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
     setMaximumSize(41+24+24, 41+24+24);
     setMinimumSize(41+24+24, 41+24+24);
 
-    QImage centre;
-    QImage left;
-    QImage top;
-    QImage right;
-    QImage bottom;
-    QImage tab;
+    initializeStickersImages();
 
-    centre = QImage(":/dockingBitmaps/centre_active.png");
-    left  = QImage(":/dockingBitmaps/window_left_active.png");
-    top  = QImage(":/dockingBitmaps/window_top_active.png");
-    right  = QImage(":/dockingBitmaps/window_right_active.png");
-    bottom  = QImage(":/dockingBitmaps/window_bottom_active.png");
-    tab  = QImage(":/dockingBitmaps/tab.png");
+    m_rcCentre.setTopLeft(QPoint((this->width()/2)-(m_activeStickers.value(Centre).width()/2),(this->height()/2)-(m_activeStickers.value(Centre).height()/2)));
+    m_rcCentre.setSize(m_activeStickers.value(Centre).size());
 
-    m_rcCentre.setTopLeft(QPoint((this->width()/2)-(centre.width()/2),(this->height()/2)-(centre.height()/2)));
-    m_rcCentre.setSize(centre.size());
+    m_rcLeft.setTopLeft(QPoint(0,(this->height()/2)-(m_activeStickers.value(Left).height()/2)));
+    m_rcLeft.setSize(m_activeStickers.value(Left).size());
 
-    m_rcLeft.setTopLeft(QPoint(0,(this->height()/2)-(left.height()/2)));
-    m_rcLeft.setSize(left.size());
+    m_rcRight.setTopLeft(QPoint(this->width()-m_activeStickers.value(Right).width(),(this->height()/2)-(m_activeStickers.value(Left).height()/2)));
+    m_rcRight.setSize(m_activeStickers.value(Right).size());
 
-    m_rcRight.setTopLeft(QPoint(this->width()-right.width(),(this->height()/2)-(left.height()/2)));
-    m_rcRight.setSize(right.size());
+    m_rcTop.setTopLeft(QPoint((this->width()/2)-(m_activeStickers.value(Top).width()/2), 0));
+    m_rcTop.setSize(m_activeStickers.value(Top).size());
 
-    m_rcTop.setTopLeft(QPoint((this->width()/2)-(top.width()/2), 0));
-    m_rcTop.setSize(top.size());
+    m_rcBottom.setTopLeft(QPoint((this->width()/2)-(m_activeStickers.value(Top).width()/2), (this->height()-m_activeStickers.value(Top).height())));
+    m_rcBottom.setSize(m_activeStickers.value(Bottom).size());
 
-    m_rcBottom.setTopLeft(QPoint((this->width()/2)-(top.width()/2), (this->height()-top.height())));
-    m_rcBottom.setSize(bottom.size());
-
-    m_rcTab.setTopLeft(QPoint((this->width()/2)-(tab.width()/2),(this->height()/2)-(tab.height()/2)));
-    m_rcTab.setSize(tab.size());
+    m_rcTab.setTopLeft(QPoint((this->width()/2)-(m_activeStickers.value(Tab).width()/2),(this->height()/2)-(m_activeStickers.value(Tab).height()/2)));
+    m_rcTab.setSize(m_activeStickers.value(Tab).size());
 
     m_frameLeftSticker = new DockingFrameFrameSticker("frame_left", this);
     m_frameRightSticker = new DockingFrameFrameSticker("frame_right", this);
@@ -81,37 +69,14 @@ void DockingFrameStickers::paintEvent(QPaintEvent*)
 {
     QPainter p(this);
 
-    QImage centre;
-    QImage left;
-    QImage top;
-    QImage right;
-    QImage bottom;
-    QImage tab;
-
-    if (m_isActive) {
-        centre = QImage(":/dockingBitmaps/centre_active.png");
-        left  = QImage(":/dockingBitmaps/window_left_active.png");
-        top  = QImage(":/dockingBitmaps/window_top_active.png");
-        right  = QImage(":/dockingBitmaps/window_right_active.png");
-        bottom  = QImage(":/dockingBitmaps/window_bottom_active.png");
-        tab  = QImage(":/dockingBitmaps/tab.png");
-    } else {
-        centre = QImage(":/dockingBitmaps/centre_inactive.png");
-        left  = QImage(":/dockingBitmaps/window_left_inactive.png");
-        top  = QImage(":/dockingBitmaps/window_top_inactive.png");
-        right  = QImage(":/dockingBitmaps/window_right_inactive.png");
-        bottom  = QImage(":/dockingBitmaps/window_bottom_inactive.png");
-        tab  = QImage(":/dockingBitmaps/tab.png");
-    }
-
-    p.drawImage(m_rcCentre, centre);
-    p.drawImage(m_rcLeft, left);
-    p.drawImage(m_rcRight, right);
-    p.drawImage(m_rcTop, top);
-    p.drawImage(m_rcBottom, bottom);
+    p.drawImage(m_rcCentre, m_isActive ? m_activeStickers.value(Centre) : m_inactiveStickers.value(Centre));
+    p.drawImage(m_rcLeft, m_isActive ? m_activeStickers.value(Left) : m_inactiveStickers.value(Left));
+    p.drawImage(m_rcRight, m_isActive ? m_activeStickers.value(Right) : m_inactiveStickers.value(Right));
+    p.drawImage(m_rcTop, m_isActive ? m_activeStickers.value(Top) : m_inactiveStickers.value(Top));
+    p.drawImage(m_rcBottom, m_isActive ? m_activeStickers.value(Bottom) : m_inactiveStickers.value(Bottom));
 
     if (m_tabVisible) {
-        p.drawImage(m_rcTab, tab);
+        p.drawImage(m_rcTab, m_isActive ? m_activeStickers.value(Tab) : m_inactiveStickers.value(Tab));
     }
 }
 
@@ -197,6 +162,23 @@ void DockingFrameStickers::showEvent(QShowEvent*)
     m_frameRightSticker->show();
     m_frameTopSticker->show();
     m_frameBottomSticker->show();
+}
+
+void DockingFrameStickers::initializeStickersImages()
+{
+    m_activeStickers.insert(Centre, QImage(":/dockingBitmaps/centre_active.png"));
+    m_activeStickers.insert(Left, QImage(":/dockingBitmaps/window_left_active.png"));
+    m_activeStickers.insert(Right, QImage(":/dockingBitmaps/window_right_active.png"));
+    m_activeStickers.insert(Top, QImage(":/dockingBitmaps/window_top_active.png"));
+    m_activeStickers.insert(Bottom, QImage(":/dockingBitmaps/window_bottom_active.png"));
+    m_activeStickers.insert(Tab, QImage(":/dockingBitmaps/tab.png"));
+
+    m_inactiveStickers.insert(Centre, QImage(":/dockingBitmaps/centre_inactive.png"));
+    m_inactiveStickers.insert(Left, QImage(":/dockingBitmaps/window_left_inactive.png"));
+    m_inactiveStickers.insert(Right, QImage(":/dockingBitmaps/window_right_inactive.png"));
+    m_inactiveStickers.insert(Top, QImage(":/dockingBitmaps/window_top_inactive.png"));
+    m_inactiveStickers.insert(Bottom, QImage(":/dockingBitmaps/window_bottom_inactive.png"));
+    m_inactiveStickers.insert(Tab, QImage(":/dockingBitmaps/tab.png"));
 }
 
 void DockingFrameStickers::setFrameRect(QRect rect)

--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -25,7 +25,9 @@
 #include "DockingPaneManager.h"
 
 DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
-    QWidget(parent)
+    QWidget(parent),
+    m_isActive(false),
+    m_tabVisible(false)
 {
     setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
 
@@ -36,8 +38,6 @@ DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
     setBaseSize(41+24+24, 41+24+24);
     setMaximumSize(41+24+24, 41+24+24);
     setMinimumSize(41+24+24, 41+24+24);
-
-    m_isActive = false;
 
     QImage centre;
     QImage left;

--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -77,10 +77,8 @@ DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
     m_frameBottomSticker = new DockingFrameFrameSticker("frame_bottom");
 }
 
-void DockingFrameStickers::paintEvent(QPaintEvent* event)
+void DockingFrameStickers::paintEvent(QPaintEvent*)
 {
-    Q_UNUSED(event);
-
     QPainter p(this);
 
     QImage centre;
@@ -185,20 +183,16 @@ bool DockingFrameStickers::getHit(QPoint pos, DockingFrameStickers::DockingPosit
     return(false);
 }
 
-void DockingFrameStickers::hideEvent(QHideEvent *e)
+void DockingFrameStickers::hideEvent(QHideEvent*)
 {
-    Q_UNUSED(e);
-
     m_frameLeftSticker->hide();
     m_frameRightSticker->hide();
     m_frameTopSticker->hide();
     m_frameBottomSticker->hide();
 }
 
-void DockingFrameStickers::showEvent(QShowEvent *e)
+void DockingFrameStickers::showEvent(QShowEvent*)
 {
-    Q_UNUSED(e);
-
     m_frameLeftSticker->show();
     m_frameRightSticker->show();
     m_frameTopSticker->show();

--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -47,7 +47,7 @@ DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
     m_rcLeft.setTopLeft(QPoint(0,(this->height()/2)-(m_activeStickers.value(Left).height()/2)));
     m_rcLeft.setSize(m_activeStickers.value(Left).size());
 
-    m_rcRight.setTopLeft(QPoint(this->width()-m_activeStickers.value(Right).width(),(this->height()/2)-(m_activeStickers.value(Left).height()/2)));
+    m_rcRight.setTopLeft(QPoint(this->width()-m_activeStickers.value(Right).width(),(this->height()/2)-(m_activeStickers.value(Right).height()/2)));
     m_rcRight.setSize(m_activeStickers.value(Right).size());
 
     m_rcTop.setTopLeft(QPoint((this->width()/2)-(m_activeStickers.value(Top).width()/2), 0));

--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -71,10 +71,10 @@ DockingFrameStickers::DockingFrameStickers(QWidget *parent) :
     m_rcTab.setTopLeft(QPoint((this->width()/2)-(tab.width()/2),(this->height()/2)-(tab.height()/2)));
     m_rcTab.setSize(tab.size());
 
-    m_frameLeftSticker = new DockingFrameFrameSticker("frame_left");
-    m_frameRightSticker = new DockingFrameFrameSticker("frame_right");
-    m_frameTopSticker = new DockingFrameFrameSticker("frame_top");
-    m_frameBottomSticker = new DockingFrameFrameSticker("frame_bottom");
+    m_frameLeftSticker = new DockingFrameFrameSticker("frame_left", this);
+    m_frameRightSticker = new DockingFrameFrameSticker("frame_right", this);
+    m_frameTopSticker = new DockingFrameFrameSticker("frame_top", this);
+    m_frameBottomSticker = new DockingFrameFrameSticker("frame_bottom", this);
 }
 
 void DockingFrameStickers::paintEvent(QPaintEvent*)

--- a/src/DockingFrameStickers.cpp
+++ b/src/DockingFrameStickers.cpp
@@ -17,9 +17,11 @@
  * along with DockingPanes.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "DockingFrameStickers.h"
-#include <QPainter>
 #include <QDebug>
+#include <QPainter>
+
+#include "DockingFrameFrameSticker.h"
+#include "DockingFrameStickers.h"
 #include "DockingPaneManager.h"
 
 DockingFrameStickers::DockingFrameStickers(QWidget *parent) :

--- a/src/DockingFrameStickers.h
+++ b/src/DockingFrameStickers.h
@@ -20,6 +20,7 @@
 #ifndef DOCKINGFRAMECENTRESTICKER_H
 #define DOCKINGFRAMECENTRESTICKER_H
 
+#include <QMap>
 #include <QWidget>
 
 class QPaintEvent;
@@ -58,6 +59,17 @@ class DockingFrameStickers : public QWidget
         virtual void showEvent(QShowEvent *e) override;
 
     private:
+        enum StickerPosition
+        {
+            Centre,
+            Left,
+            Right,
+            Top,
+            Bottom,
+            Tab,
+        };
+
+        void initializeStickersImages(void);
         bool m_isActive;
         bool m_tabVisible;
 
@@ -72,6 +84,10 @@ class DockingFrameStickers : public QWidget
         DockingFrameFrameSticker *m_frameRightSticker;
         DockingFrameFrameSticker *m_frameTopSticker;
         DockingFrameFrameSticker *m_frameBottomSticker;
+
+        QMap<StickerPosition, QImage> m_activeStickers;
+        QMap<StickerPosition, QImage> m_inactiveStickers;
+
 };
 
 #endif // DOCKINGFRAMECENTRESTICKER_H

--- a/src/DockingFrameStickers.h
+++ b/src/DockingFrameStickers.h
@@ -53,9 +53,9 @@ class DockingFrameStickers : public QWidget
         bool getHit(QPoint pos, DockingPosition *dockPos);
 
     protected:
-        virtual void paintEvent(QPaintEvent* event);
-        void hideEvent(QHideEvent *e);
-        void showEvent(QShowEvent *e);
+        virtual void paintEvent(QPaintEvent* event) override;
+        virtual void hideEvent(QHideEvent *e) override;
+        virtual void showEvent(QShowEvent *e) override;
 
     private:
         bool m_isActive;

--- a/src/DockingFrameStickers.h
+++ b/src/DockingFrameStickers.h
@@ -45,21 +45,17 @@ class DockingFrameStickers : public QWidget
         };
 
     public:
-        explicit DockingFrameStickers(QWidget *parent = 0);
-        
+        explicit DockingFrameStickers(QWidget *parent = nullptr);
+
         void setFrameRect(QRect rect);
         void updateCursorPos(QPoint pos);
         void setTabVisible(bool state);
         bool getHit(QPoint pos, DockingPosition *dockPos);
 
-    signals:
-
     protected:
         virtual void paintEvent(QPaintEvent* event);
         void hideEvent(QHideEvent *e);
         void showEvent(QShowEvent *e);
-
-    public slots:
 
     private:
         bool m_isActive;

--- a/src/DockingFrameStickers.h
+++ b/src/DockingFrameStickers.h
@@ -21,9 +21,11 @@
 #define DOCKINGFRAMECENTRESTICKER_H
 
 #include <QWidget>
-#include "DockingFrameFrameSticker.h"
 
 class QPaintEvent;
+
+class DockingFrameFrameSticker;
+
 class DockingFrameStickers : public QWidget
 {
     Q_OBJECT


### PR DESCRIPTION
More or less the same as my previous PRs.

In this case, however, I tried to simplify the `QImage`'s handling, by adding:
* First, an private `enum StickerPosition`. I wanted to use the existing one but they seemed to be incompatible :(
* Second, Two `QMap<StickerPosition, QImage>` members, for both active and inactive images. These maps will be initialized once on the constructor by calling a method `initializeStickersImages()`.
This change allows `paintEvent()` to access those images in a faster way thanks to the `QMap` internal implementation.

I've tested my changes on a windows build, and it does not seem to be any noticeable change (which is good for this kind of PR). Anyway, please let me know WDYT about those changes. Thanks!